### PR TITLE
Harden backend security for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ cp env.example .env
 # DB_NAME=rare_parfume
 # DB_USER=postgres
 # DB_PASSWORD=your_password
+# ALLOWED_ORIGINS=https://rareparfume.com,https://admin.rareparfume.com
+# JWT_SECRET=chuoi_bao_mat_it_nhat_32_ky_tu
 
 # Khởi động server
 npm run dev
@@ -255,6 +257,12 @@ Website được thiết kế responsive hoàn toàn, hỗ trợ tất cả các
 - `DELETE /api/admin/products/:id` - Xóa sản phẩm
 
 ## 🚀 Deployment
+
+### 🔐 Lưu ý bảo mật trước khi deploy
+- Thiết lập biến môi trường `NODE_ENV=production` và cung cấp `JWT_SECRET` tối thiểu 32 ký tự.
+- Cập nhật `ALLOWED_ORIGINS` với danh sách domain thật (ví dụ: `https://rareparfume.com,https://admin.rareparfume.com`).
+- Đặt lại `ADMIN_EMAIL` và `ADMIN_PASSWORD` bằng thông tin riêng, tránh giữ giá trị mặc định.
+- Bật HTTPS (ví dụ thông qua reverse proxy/Heroku SSL) để bảo vệ dữ liệu đăng nhập và thanh toán.
 
 ### Backend (Heroku)
 ```bash

--- a/backend/config/security.js
+++ b/backend/config/security.js
@@ -1,0 +1,34 @@
+const parseList = (value = '') => {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const nodeEnv = (process.env.NODE_ENV || 'development').trim();
+const isProduction = nodeEnv === 'production';
+
+let jwtSecret = process.env.JWT_SECRET;
+if (!jwtSecret) {
+  if (isProduction) {
+    throw new Error('JWT_SECRET environment variable is required in production environments');
+  }
+
+  console.warn('⚠️  JWT_SECRET is not set. Falling back to a weak development secret.');
+  jwtSecret = 'development-secret-change-me';
+}
+
+if (isProduction && jwtSecret.length < 32) {
+  throw new Error('JWT_SECRET must be at least 32 characters long in production');
+}
+
+const allowedOrigins = parseList(process.env.ALLOWED_ORIGINS || process.env.FRONTEND_URL || '');
+const allowAllInDev = !allowedOrigins.length && !isProduction;
+
+module.exports = {
+  allowedOrigins,
+  allowAllInDev,
+  isProduction,
+  jwtSecret,
+  nodeEnv
+};

--- a/backend/create-admin-user.js
+++ b/backend/create-admin-user.js
@@ -7,6 +7,14 @@ async function createAdminUser() {
     const adminEmail = process.env.ADMIN_EMAIL || 'admin@rareparfume.com';
     const adminPassword = process.env.ADMIN_PASSWORD || 'admin123';
 
+    if (adminPassword === 'admin123') {
+      console.warn('⚠️  ADMIN_PASSWORD is using the default value. Please change it before deploying.');
+    }
+
+    if (adminPassword.length < 12) {
+      console.warn('⚠️  ADMIN_PASSWORD should be at least 12 characters for better security.');
+    }
+
     // Hash the password
     const saltRounds = 12;
     const passwordHash = await bcrypt.hash(adminPassword, saltRounds);

--- a/backend/env.example
+++ b/backend/env.example
@@ -7,6 +7,9 @@ NODE_ENV=development
 # Frontend URL
 FRONTEND_URL=http://localhost:3000
 
+# Allowed origins (comma separated list). Required in production.
+ALLOWED_ORIGINS=http://localhost:3000
+
 # Database Configuration
 DB_HOST=localhost
 DB_PORT=5432
@@ -14,13 +17,13 @@ DB_NAME=rare_parfume
 DB_USER=postgres
 DB_PASSWORD=your_password_here
 
-# JWT Secret (generate a strong secret for production)
-JWT_SECRET=your_jwt_secret_here
+# JWT Secret (generate a strong secret for production, >=32 characters)
+JWT_SECRET=your_super_secure_jwt_secret_change_me
 
 # File Upload Configuration
 MAX_FILE_SIZE=5242880
 UPLOAD_PATH=./uploads
 
-# Admin Configuration
+# Admin Configuration (đổi mật khẩu trước khi deploy)
 ADMIN_EMAIL=admin@rareparfume.com
-ADMIN_PASSWORD=admin123
+ADMIN_PASSWORD=change_me_secure_password

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -3,6 +3,7 @@ const { body, validationResult, query } = require('express-validator');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const { dbGet, dbAll, dbRun } = require('../config/database');
+const { jwtSecret } = require('../config/security');
 const router = express.Router();
 
 const parseProduct = (product) => {
@@ -72,7 +73,6 @@ const verifyAdminToken = async (req, res, next) => {
       return res.status(401).json({ error: 'No token provided' });
     }
 
-    const jwtSecret = process.env.JWT_SECRET || 'rare_parfume_jwt_secret_2024';
     const decoded = jwt.verify(token, jwtSecret);
     
     // Verify admin user exists and is active
@@ -121,7 +121,7 @@ router.post('/login', [
 
     const token = jwt.sign(
       { userId: admin.id, email: admin.email },
-      process.env.JWT_SECRET || 'rare_parfume_jwt_secret_2024',
+      jwtSecret,
       { expiresIn: '24h' }
     );
     res.json({

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const path = require('path');
+const { allowedOrigins, allowAllInDev, isProduction, nodeEnv } = require('./config/security');
 
 // Import routes
 const productRoutes = require('./routes/products');
@@ -13,44 +14,59 @@ const adminRoutes = require('./routes/admin');
 const app = express();
 const PORT = process.env.PORT || 5000;
 
+app.disable('x-powered-by');
+
 // Trust proxy for accurate IP detection (for rate limiting)
 app.set('trust proxy', 1);
 
 // Security middleware
-app.use(helmet());
+app.use(helmet({
+  contentSecurityPolicy: isProduction ? undefined : false,
+  crossOriginResourcePolicy: { policy: 'cross-origin' }
+}));
 
 // Rate limiting
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100 // limit each IP to 100 requests per windowMs
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false
 });
 app.use(limiter);
 
-// CORS configuration - More flexible for development
-app.use(cors({
-  origin: function (origin, callback) {
-    // Allow requests with no origin (like mobile apps or curl requests)
-    if (!origin) return callback(null, true);
-
-    // Allow localhost on any port for development
-    if (origin.includes('localhost') || origin.includes('127.0.0.1')) {
+// CORS configuration - Restrictive by default
+const corsOptions = {
+  origin(origin, callback) {
+    if (!origin) {
       return callback(null, true);
     }
 
-    // Allow file:// protocol for local development
-    if (origin.startsWith('file://')) {
+    if (allowedOrigins.includes(origin)) {
       return callback(null, true);
     }
 
-    // For production, you might want to restrict origins
-    // For now, allow all origins in development
-    console.log('⚠️  Allowing CORS for origin:', origin);
-    callback(null, true);
+    if (allowAllInDev) {
+      console.warn(`⚠️  Allowing non-whitelisted CORS origin in development: ${origin}`);
+      return callback(null, true);
+    }
+
+    console.warn(`🚫 Blocked request from disallowed origin: ${origin}`);
+    return callback(new Error('Not allowed by CORS'));
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With']
-}));
+};
+
+const applyCors = cors(corsOptions);
+app.use((req, res, next) => {
+  applyCors(req, res, (corsError) => {
+    if (corsError) {
+      return res.status(403).json({ error: 'Origin not allowed by CORS' });
+    }
+    next();
+  });
+});
 
 // Body parsing middleware
 app.use(express.json({ limit: '10mb' }));
@@ -74,7 +90,7 @@ app.use((err, req, res, next) => {
   console.error(err.stack);
   res.status(500).json({ 
     error: 'Something went wrong!',
-    message: process.env.NODE_ENV === 'development' ? err.message : 'Internal server error'
+    message: nodeEnv === 'development' ? err.message : 'Internal server error'
   });
 });
 

--- a/backend/update-admin-password.js
+++ b/backend/update-admin-password.js
@@ -7,6 +7,14 @@ async function updateAdminPassword() {
     const adminEmail = process.env.ADMIN_EMAIL || 'admin@rareparfume.com';
     const adminPassword = process.env.ADMIN_PASSWORD || 'admin123';
 
+    if (adminPassword === 'admin123') {
+      console.warn('⚠️  ADMIN_PASSWORD is using the default value. Please change it before deploying.');
+    }
+
+    if (adminPassword.length < 12) {
+      console.warn('⚠️  ADMIN_PASSWORD should be at least 12 characters for better security.');
+    }
+
     // Hash the password
     const saltRounds = 12;
     const passwordHash = await bcrypt.hash(adminPassword, saltRounds);


### PR DESCRIPTION
## Summary
- centralize security configuration to validate JWT secrets, restrict CORS, and harden Express defaults
- warn about weak admin credentials in helper scripts and document required deployment environment variables

## Testing
- npm --prefix backend test *(fails: No tests found, run with --passWithNoTests)*

------
https://chatgpt.com/codex/tasks/task_e_68e613c0810483268fcff21702aa8008